### PR TITLE
Add section to provide step for testing SimpleSAMLphp library

### DIFF
--- a/readme/simplesamlphp-setup.md
+++ b/readme/simplesamlphp-setup.md
@@ -115,6 +115,16 @@ Request the remote IdP metadata (XML) from the customer. Note that each environm
 
 1. Commit your changes to your Git repository.
 
+## Testing Library Configuration
+
+Once you have completed the code changes above, you should proceed with testing the configuration of SimpleSAMLphp as a Service Provider connecting to your specified Identity Provider.
+
+You can do this by navigating to Go to the path `/simplesaml/module.php/core/authenticate.php` on your application to access the SimpleSAMLphp library Test authentication sources page. On this page you will need to click the authsource to test. It should be default-sp unless configured otherwise.
+
+If it successfully connects and authenticates it will return you to a page in the SimpleSAML interface where it will list the attributes returned by the IdP. Make a note of these attributes because they will be used to configure the SimpleSAMLphp_auth Drupal module.
+
+If you are unable to connect, there’s typically variations in how your authsources.php can be setup depending on the IdP that’s being used, so the testing phase in the library is crucial in determining what changes if any need to be made.
+
 ## Module Configuration
 
 Be careful with the following steps as misconfiguration could effectively lock you out of your site. It is probably best to allow at least user 1 to continue to use "local authentication" until you have confirmed that everything works.


### PR DESCRIPTION
Changes proposed:
- Add section describing process to test the SimpleSAMLphp library config before proceeding with Drupal module config.
